### PR TITLE
Explicit licensing, switch to CC BY 4.0 for everything

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,6 @@
+All the material in this repository is licensed under [CC BY
+4.0](//creativecommons.org/licenses/by/4.0/).
+
+(please add your name below if you have contributed to the proposal)
+
+Copyright 2016 Tim Head

--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ needs improving, is missing, is incorrect, or add an idea of your
 own. Or directly create a pull request with your suggested edits.
 
 As this is about creating a entry for the open science prize, creating
-the entry should happen in the open as well. All the material is
-licensed under [CC BY-SA
-4.0](//creativecommons.org/licenses/by-sa/4.0/).
+the entry should happen in the open as well. Licensing details and a
+list of contributors can be found in [LICENSE](LICENSE).
 
 
 # Longer outline of the idea


### PR DESCRIPTION
This moves the license to a separate file and switches everything to CC BY 4.0

So far I am the only contributor so I think no one else needs to consent to switching the license.

This is in response to #4. What do you think @Daniel-Mietchen?

What license the output of this proposal (if it is chosen) should use is something to discuss in the actual proposal and isn't covered by LICENSE. My preference would be to write something like:

```
Work contributed to existing open source projects will be licensed under that projects terms. When a new project is created it should use the BSD (for code) or CC BY 4.0 (training material) license.
```

Basically choose as permissive a license as possible.