### PR TITLE
Abstract in its own file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
-pdf: proposal.md
-	pandoc -V colorlinks proposal.md -o proposal.pdf
+pdf: proposal.pdf abstract.pdf
+
+%.pdf: %.md
+	pandoc -V colorlinks $< -o $@

--- a/abstract.md
+++ b/abstract.md
@@ -1,0 +1,36 @@
+# Everpub: reusable research, 21st century style
+
+## Abstract
+
+Modern research is strongly dependent on computational tools. In
+biomedical research, computers are indispensible for analyzing large
+amounts of data and for understanding complex models through
+simulation. While the rapid advance of computing technology has
+boosted progress in many fields of science, it has also created
+barriers for scientific communication, which are particularly painful
+in the ongoing transition to Open Science. Permitting other
+researchers, let alone non-specialists, to fully understand complex research
+requires not only publishing software and datasets, but also providing
+a computational environment in which readers can explore these methods
+easily by changing parameters and input data.
+
+Over the last years, a large number of tools have been developed that
+address specific aspects of this problem, and much valuable experience
+has been gained from their use. However, orchestrating all these tools
+for either producing or exploring published research requires a level of
+technical competence that few scientists have or even wish to
+acquire. We propose to drive a vertical spike through this problem
+space, by integrating existing tools and methods into a unified whole
+whose use requires no more technical expertise than performing
+computations on a desktop computer. As a consequence, scientists will
+be able to understand, evaluate, and re-use the work of
+their peers.
+
+We emphasize that we do not expect to provide a definitive solution to
+the problem in the near future. Our immediate goal is to provide a
+usable platform for publishing computer-aided research, which will
+then be improved over time by bringing onboard scientists, librarians,
+and publishers. We aim at building a community around these ideas,
+which is a critical part of the success of the project. In addition to
+_enabling_ Open Science, this project is also meant to be an _example_
+of Open Science.

--- a/char-count.sh
+++ b/char-count.sh
@@ -2,3 +2,6 @@
 echo 'proposal.md contains'
 cat proposal.md | tr -d " \t\n\r#" | wc -m
 echo 'characters'
+echo 'abstract.md contains'
+wc -w abstract.md 
+echo 'words'

--- a/proposal.md
+++ b/proposal.md
@@ -4,41 +4,6 @@ Tim Head (Europe lead)
 
 Titus Brown (US lead)
 
-## Abstract:
-
-Modern research is strongly dependent on computational tools. In
-biomedical research, computers are indispensible for analyzing large
-amounts of data and for understanding complex models through
-simulation. While the rapid advance of computing technology has
-boosted progress in many fields of science, it has also created
-barriers for scientific communication, which are particularly painful
-in the ongoing transition to Open Science. Permitting other
-researchers, let alone non-specialists, to fully understand complex research
-requires not only publishing software and datasets, but also providing
-a computational environment in which readers can explore these methods
-easily by changing parameters and input data.
-
-Over the last years, a large number of tools have been developed that
-address specific aspects of this problem, and much valuable experience
-has been gained from their use. However, orchestrating all these tools
-for either producing or exploring published research requires a level of
-technical competence that few scientists have or even wish to
-acquire. We propose to drive a vertical spike through this problem
-space, by integrating existing tools and methods into a unified whole
-whose use requires no more technical expertise than performing
-computations on a desktop computer. As a consequence, scientists will
-be able to understand, evaluate, and re-use the work of
-their peers.
-
-We emphasize that we do not expect to provide a definitive solution to
-the problem in the near future. Our immediate goal is to provide a
-usable platform for publishing computer-aided research, which will
-then be improved over time by bringing onboard scientists, librarians,
-and publishers. We aim at building a community around these ideas,
-which is a critical part of the success of the project. In addition to
-_enabling_ Open Science, this project is also meant to be an _example_
-of Open Science.
-
 
 ## Introduction:
 


### PR DESCRIPTION
The abstract now has its own file.

```
$ ./char-count.sh
proposal.md contains
   16103
characters
abstract.md contains
     300 abstract.md
words
```

We need to get rid of around 1000characters in the proposal or claim that these don't count as they are hyperlinks. Ideas?